### PR TITLE
Beartype 0.3.1.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "beartype" %}
-{% set version = "0.3.0" %}
-{% set sha256 = "99b15566b2e17f30f20586c14201eeca934acfa98df20705628d8f6c017cacf2" %}
+{% set version = "0.3.1" %}
+{% set sha256 = "dafba17388cd145f60dbb8d9052bcbc9a4c1d1adcd98e16871ce13d31fde8be9" %}
 
 package:
   name: {{ name|lower }}
@@ -18,11 +18,11 @@ build:
 
 requirements:
   host:
-    - python >=3.5
+    - python >=3.6
     - pip
     - setuptools
   run:
-    - python >=3.5
+    - python >=3.6
 
 test:
   requires:


### PR DESCRIPTION
This commit bumps both the condaforge-hosted package for beartype to its next stable release *and* the minimum major version of Python internally required by this package to Python 3.6, reflecting the recent EOL for Python 3.5.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
