### PR TITLE
Upstream documentation URL change.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . -vv
   noarch: python
 
@@ -56,7 +56,7 @@ about:
     worst case) as equivalent type-checking implemented by hand. Beartype thus
     brings Rust- and C++-inspired zero-cost abstractions into the deliciously
     lawless world of pure Python.
-  doc_url: https://github.com/beartype/beartype/blob/master/README.rst
+  doc_url: https://github.com/beartype/beartype/blob/main/README.rst
   dev_url: https://github.com/beartype/beartype
 
 extra:


### PR DESCRIPTION
This commit revises the external URL of the front-facing documentation
for this project to the newly instated "main" branch, previously known
as the non-inclusive "master" branch.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
