### PR TITLE
CFEP-25.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,21 +12,22 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . -vv
   noarch: python
 
 requirements:
   host:
-    - python >=3.8
+    - python {{ python_min }}
     - hatchling >=1.14.0
     - pip
   run:
-    - python >=3.8
+    - python >={{ python_min }}
 
 test:
   requires:
     - pytest
+    - python {{ python_min }}
   source_files:
     - conftest.py
     - beartype_test
@@ -40,8 +41,9 @@ about:
   license_file: LICENSE
   summary: Unbearably fast near-real-time hybrid runtime-static type-checking. Unbearably fast runtime type checking in pure Python.
   description: |
-    Beartype is an open-source PEP-compliant near-real-time pure-Python runtime
-    type checker emphasizing efficiency, usability, and thrilling puns.
+    Beartype is an open-source PEP-compliant near-real-time pure-Python hybrid
+    runtime-static type checker emphasizing efficiency, usability, and thrilling
+    puns.
   doc_url: https://beartype.readthedocs.io
   dev_url: https://github.com/beartype/beartype
 


### PR DESCRIPTION
This PR implements support for **[CFEP-25](https://github.com/conda-forge/cfep/blob/main/cfep-25.md)** (i.e., `noarch: python`-specific `python {{ python_min }}` syntax). I am brimming with optimism. This PR:

* Resolves @beartype issue #526 kindly submitted by @MilesCranmer – a superstar of our time! :star_struck: 
* Supercedes the now-obsolete prior PR #47.

CFEP-25 generalizes pure-Python Conda recipes to dynamically require the minimum Python version currently supported by @conda-forge itself. Previously, most pure-Python Conda recipes (including this one) hard-coded a minimum Python version -- typically resulting in catastrophic breakage on major Python bumps.

Thanks so much for prodding us to finally do the right thing, @MilesCranmer! Truly, Cambridge is never wrong. :sweat: 

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
